### PR TITLE
Enable to specify job xml dir.

### DIFF
--- a/src/clj/job_streamer/agent/config.clj
+++ b/src/clj/job_streamer/agent/config.clj
@@ -14,5 +14,5 @@
      :beacon    {:port port}
      :runtime {:instance-id (some-> (env :instance-name)
                                     (.getBytes)
-                                    (UUID/nameUUIDFromBytes))}}))
-
+                                    (UUID/nameUUIDFromBytes))
+               :job-xml-dir (env :job-xml-dir)}}))


### PR DESCRIPTION
I fixed it to get JOB_XML_DIR from environment variables and use the path to create temp job file.